### PR TITLE
同じ商品を複数個カートに入れられるように修正

### DIFF
--- a/ecommerce_website/ecommerce/templates/cart_list.html
+++ b/ecommerce_website/ecommerce/templates/cart_list.html
@@ -12,12 +12,14 @@
       <th>商品番号</th>
       <th>商品名</th>
       <th>価格</th>
+      <th>個数</th>
     </tr>
-    {% for product in products %}
+    {% for detail in details %}
     <tr>
-      <td>{{ product.id }}</td>
-      <td>{{ product.name }}</td>
-      <td class="cart-list_goods_list-price">{{ product.price }}</td>
+      <td>{{ detail.product.id }}</td>
+      <td>{{ detail.product.name }}</td>
+      <td class="cart-list_goods_list-price">{{ detail.product.price }}</td>
+      <td>{{ detail.count }}</td>
     </tr>
     {% endfor %}
   </table>

--- a/ecommerce_website/ecommerce/templates/order.html
+++ b/ecommerce_website/ecommerce/templates/order.html
@@ -11,15 +11,22 @@
         <th>商品番号</th>
         <th>商品名</th>
         <th>価格</th>
+        <th>個数</th>
+        <th>小計</th>
     </tr>
-{% for product in products %}
+{% for detail in details %}
     <tr>
-        <td>{{ product.id }}</td>
-        <td>{{ product.name }}</td>
-        <td>{{ product.price }}</td>
+        <td>{{ detail.product.id }}</td>
+        <td>{{ detail.product.name }}</td>
+        <td>{{ detail.product.price }}</td>
+        <td>{{ detail.count }}</td>
+        <td>{{ detail.subtotal }}</td>
     </tr>
 {% endfor %}
 </table>
+<div>
+  <span>合計: </span><span>{{ total }}円</span>
+</div>
 
 <h1>お客様情報の入力</h1>
 <form action="../order_execute/" method="post">

--- a/ecommerce_website/ecommerce/templates/product_list.html
+++ b/ecommerce_website/ecommerce/templates/product_list.html
@@ -13,7 +13,7 @@
       <img class="product-list_image" src="../../media/{{ product.image }}" alt="" width="200" height="200" border="0" />
       <div class="product-list_information">
         <h1 class="product-list_name">{{ product.name }}</h1>
-        <a class="product-list_cart-button" href="../cart_add/{{ product.id }}">カートに入れる</a>
+        <a class="product-list_cart-button" href="../cart_add/{{ product.id }}/?count=1">カートに入れる</a>
         <p><a href="../good_add/{{ product.id }}">いいね！</a>{{ product.good }}</p>
       </div>
     </div>

--- a/ecommerce_website/ecommerce/views.py
+++ b/ecommerce_website/ecommerce/views.py
@@ -31,10 +31,16 @@ def cart_add(request, product_id):
         request.session['cart'] = list()
 
     cart = request.session['cart']
-    cart.append({
-        'product_id': product_id,
-        'count': request.GET.get('count'),
-    })
+
+    if any([item['product_id'] == product_id for item in cart]):
+        item = [item for item in cart if item['product_id'] == product_id][0]
+        item['count'] = str(int(item['count']) + 1)
+    else:
+        cart.append({
+            'product_id': product_id,
+            'count': request.GET.get('count'),
+        })
+
     request.session['cart'] = cart
 
     products = get_list_or_404(Product)
@@ -95,7 +101,15 @@ def cart_list(request):
     #   カートに入っている商品の情報を取得します
     products = Product.objects.filter(id__in=[item['product_id'] for item in cart])
 
-    return render(request, 'cart_list.html', {'products': products})
+    details = []
+
+    for product in products:
+        details.append({
+            'product': product,
+            'count': [item for item in cart if item['product_id'] == str(product.id)][0]['count']
+        })
+
+    return render(request, 'cart_list.html', {'details': details})
 
 def order(request):
     """

--- a/ecommerce_website/ecommerce/views.py
+++ b/ecommerce_website/ecommerce/views.py
@@ -29,8 +29,12 @@ def cart_add(request, product_id):
     #   カート(セッション)に商品を追加します。
     if not request.session.has_key('cart'):
         request.session['cart'] = list()
+
     cart = request.session['cart']
-    cart.append(product_id)
+    cart.append({
+        'product_id': product_id,
+        'count': request.GET.get('count'),
+    })
     request.session['cart'] = cart
 
     products = get_list_or_404(Product)
@@ -50,7 +54,7 @@ def cart_delete(request, product_id):
         request.session['cart'] = list()
     cart = request.session['cart']
     #   同じ商品が複数listに入っていた場合に、指定されてIDのオブジェクトをすべて削除する
-    cart = [item for item in cart if item is not str(product_id)]
+    cart = [item for item in cart if item['product_id'] is not str(product_id)]
     request.session['cart'] = cart
 
     products = get_list_or_404(Product)
@@ -89,7 +93,7 @@ def cart_list(request):
     cart = request.session['cart']
 
     #   カートに入っている商品の情報を取得します
-    products = Product.objects.filter(id__in=cart)
+    products = Product.objects.filter(id__in=[item['product_id'] for item in cart])
 
     return render(request, 'cart_list.html', {'products': products})
 
@@ -105,7 +109,7 @@ def order(request):
     cart = request.session['cart']
 
     #   カートに入っている商品の情報を取得します
-    products = Product.objects.filter(id__in=cart)
+    products = Product.objects.filter(id__in=[item['product_id'] for item in cart])
 
     #   決済方法を取得します。
     payments = get_list_or_404(Payment)
@@ -143,7 +147,7 @@ def order_execute(request):
     cart = request.session['cart']
 
     #   カートに入っている商品の情報を取得します
-    products = Product.objects.filter(id__in=cart)
+    products = Product.objects.filter(id__in=[item['product_id'] for item in cart])
 
     for product in products:
         order_product = Order_Product(order=order, product=product, count=1, price=product.price)

--- a/ecommerce_website/ecommerce/views.py
+++ b/ecommerce_website/ecommerce/views.py
@@ -128,7 +128,20 @@ def order(request):
     #   決済方法を取得します。
     payments = get_list_or_404(Payment)
 
-    return render(request, 'order.html', {'products': products, 'payments': payments})
+    details = []
+    total = 0
+
+    for product in products:
+        count = [item for item in cart if item['product_id'] == str(product.id)][0]['count']
+        subtotal = int(product.price) * int(count)
+        total += subtotal
+        details.append({
+            'product': product,
+            'count': count,
+            'subtotal': subtotal
+        })
+
+    return render(request, 'order.html', {'details': details, 'payments': payments, 'total': total})
 
 def order_execute(request):
     """


### PR DESCRIPTION
ひとまず、同じ商品をクリックしてカートに追加できるようにしました。
まだ、カートに入れるところまでで、実際の注文では複数個に対応していません。

とりあえず、ここまででレビューおねがいします 🙏 

session['cart']には `{ product_id: <id>, count: <count> }` のようにセットするように変更しています。